### PR TITLE
Use main branch of cace-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,19 @@ jobs:
 
       # Run CACE on the design
       - name: Run CACE for simplest_analog_switch_ena1v8
-        uses: efabless/cace-action@update
+        uses: efabless/cace-action@main
         with:
           pdk_family: 'sky130'
           cace_datasheet: 'cace/simplest_analog_switch_ena1v8.yaml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run CACE for simple_analog_switch_ena1v8
-        uses: efabless/cace-action@update
+        uses: efabless/cace-action@main
         with:
           pdk_family: 'sky130'
           cace_datasheet: 'cace/simple_analog_switch_ena1v8.yaml'
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run CACE for isolated_switch_ena1v8
-        uses: efabless/cace-action@update
+        uses: efabless/cace-action@main
         with:
           pdk_family: 'sky130'
           cace_datasheet: 'cace/isolated_switch_ena1v8.yaml'


### PR DESCRIPTION
I pushed a fix to the action that allows CACE to run on multiple designs in the CI.
This works now, but it seems that the CACE setup still needs improvements for the isolated and simple switch, also LVS is failing for all of them.